### PR TITLE
[Autofix][high] Alert #42: File created without restricting permissions

### DIFF
--- a/XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp
+++ b/XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp
@@ -555,9 +555,18 @@ bool CModuleSession_PushStream::ModuleSession_PushStream_HLSInsert(LPCXSTR lpszC
 
 	_tcsxcpy(stl_MapIterator->second->st_HLSFile.tszFileName, lpszTSFile);
 	stl_MapIterator->second->st_HLSFile.xhToken = xhToken;
-	stl_MapIterator->second->st_HLSFile.pSt_File = _xtfopen(lpszTSFile, _X("wb"));
+	int nFileHandle = _open(lpszTSFile, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE);
+	if (nFileHandle < 0)
+	{
+		Session_IsErrorOccur = true;
+		Session_dwErrorCode = ERROR_STREAMMEDIA_MODULE_SESSION_FILE;
+		st_Locker.unlock_shared();
+		return false;
+	}
+	stl_MapIterator->second->st_HLSFile.pSt_File = _fdopen(nFileHandle, "wb");
 	if (NULL == stl_MapIterator->second->st_HLSFile.pSt_File)
 	{
+		_close(nFileHandle);
 		Session_IsErrorOccur = true;
 		Session_dwErrorCode = ERROR_STREAMMEDIA_MODULE_SESSION_FILE;
 		st_Locker.unlock_shared();


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#42](https://github.com/libxengine/XEngine_StreamMedia/security/code-scanning/42) |
| **安全级别** | high |
| **规则名称** | File created without restricting permissions |
| **问题文件** | `XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp` 第 558 行 |
| **CWE 分类** | external/cwe/cwe-732 |
| **规则标签** | external/cwe/cwe-732, security |

---

### 🔍 问题说明

# File created without restricting permissions
When you create a file, take care to give it the most restrictive permissions possible. A typical mistake is to create the file with world-writable permissions. This can allow an attacker to write to the file, which can give them unexpected control over the program.


## Recommendation
Files should usually be created with write permissions only for the current user. If broader permissions are needed, including the users' group should be sufficient. It is very rare that a file needs to be world-writable, and care should be taken not to make assumptions about the contents of any such file.

On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using `umask`. However, a program should not assume t

---

### 🤖 AI 修复思路

To fix this without changing functionality, replace the direct `_xtfopen(..., "wb")` file creation with a two-step flow:

1. Create/open the file using `open`-style API flags with explicit mode `0600` (`S_IRUSR | S_IWUSR`).
2. Convert the resulting descriptor to `FILE*` using `fdopen`-style API in binary write mode.

This keeps behavior (binary write stream) while enforcing least-privilege permissions at creation time.

In `XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp`, edit the block around current line 558.  
Use `_open(..., _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE)` and then `_fdopen(fd, "wb")`.  
If `_fdopen` fails, close the fd with `_close(fd)` and return the same existing error path.

No new third-party dependency is needed; this uses standard CRT functions/macros typically available via existing headers in `pch.h`.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。