### PR TITLE
[Autofix][high] Alert #41: Incorrect allocation-error handling

### DIFF
--- a/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
+++ b/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
@@ -261,7 +261,7 @@ bool CModuleConfigure_Json::ModuleConfigure_Json_Versions(LPCXSTR lpszConfigFile
 		return false;
 	}
 	Json::Value st_JsonXVer = st_JsonRoot["XVer"];
-	pSt_ServerConfig->st_XVer.pStl_ListVer = new list<string>;
+	pSt_ServerConfig->st_XVer.pStl_ListVer = new (std::nothrow) list<string>;
 	if (NULL == pSt_ServerConfig->st_XVer.pStl_ListVer)
 	{
 		Config_IsErrorOccur = true;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#41](https://github.com/libxengine/XEngine_StreamMedia/security/code-scanning/41) |
| **安全级别** | high |
| **规则名称** | Incorrect allocation-error handling |
| **问题文件** | `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp` 第 264 行 |
| **CWE 分类** | external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755 |
| **规则标签** | correctness, external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755, security |

---

### 🔍 问题说明

# Incorrect allocation-error handling
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.


## Recommendation
Make sure that exceptions are handled appropriately if `new T` is used. On the other hand, make sure to handle the possibility of null pointers if `new(std::nothrow) T` is used.


## Example

```cpp
// BAD: the allocation will throw an unhandled exception
// instead of returning a null pointer.
void bad1(std::size_t length) noexcept {
 int* dest = new int[l

---

### 🤖 AI 修复思路

Use allocation and error handling consistently. Since the current function is written in return-code style (sets module error code and returns `false`), the best non-functional-change fix is to switch this allocation to nothrow new and keep the existing null check path.

**Specific change in** `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp`:
- In `ModuleConfigure_Json_Versions`, replace:
  - `new list<string>`  
  with:
  - `new (std::nothrow) list<string>`

This makes line 265’s null check valid and reachable on allocation failure, preserving current behavior (set `Config_IsErrorOccur`, set `ERROR_MODULE_CONFIGURE_JSON_MALLOC`, return `false`) without introducing exception handling changes.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。