### PR TITLE
[Autofix][high] Alert #42: File created without restricting permissions

### DIFF
--- a/XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp
+++ b/XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp
@@ -1,5 +1,8 @@
 ﻿#include "pch.h"
 #include "ModuleSession_PushStream.h"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 /********************************************************************
 //    Created:     2023/06/04  20:19:13
 //    File Name:   D:\XEngine_StreamMedia\XEngine_Source\XEngine_ModuleSession\ModuleSession_PushStream\ModuleSession_PushStream.cpp
@@ -555,9 +558,19 @@ bool CModuleSession_PushStream::ModuleSession_PushStream_HLSInsert(LPCXSTR lpszC
 
 	_tcsxcpy(stl_MapIterator->second->st_HLSFile.tszFileName, lpszTSFile);
 	stl_MapIterator->second->st_HLSFile.xhToken = xhToken;
-	stl_MapIterator->second->st_HLSFile.pSt_File = _xtfopen(lpszTSFile, _X("wb"));
+
+	int nFileFD = open(lpszTSFile, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	if (nFileFD < 0)
+	{
+		Session_IsErrorOccur = true;
+		Session_dwErrorCode = ERROR_STREAMMEDIA_MODULE_SESSION_FILE;
+		st_Locker.unlock_shared();
+		return false;
+	}
+	stl_MapIterator->second->st_HLSFile.pSt_File = fdopen(nFileFD, "wb");
 	if (NULL == stl_MapIterator->second->st_HLSFile.pSt_File)
 	{
+		close(nFileFD);
 		Session_IsErrorOccur = true;
 		Session_dwErrorCode = ERROR_STREAMMEDIA_MODULE_SESSION_FILE;
 		st_Locker.unlock_shared();


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#42](https://github.com/libxengine/XEngine_StreamMedia/security/code-scanning/42) |
| **安全级别** | high |
| **规则名称** | File created without restricting permissions |
| **问题文件** | `XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp` 第 558 行 |
| **CWE 分类** | external/cwe/cwe-732 |
| **规则标签** | external/cwe/cwe-732, security |

---

### 🔍 问题说明

# File created without restricting permissions
When you create a file, take care to give it the most restrictive permissions possible. A typical mistake is to create the file with world-writable permissions. This can allow an attacker to write to the file, which can give them unexpected control over the program.


## Recommendation
Files should usually be created with write permissions only for the current user. If broader permissions are needed, including the users' group should be sufficient. It is very rare that a file needs to be world-writable, and care should be taken not to make assumptions about the contents of any such file.

On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using `umask`. However, a program should not assume t

---

### 🤖 AI 修复思路

Use a file-creation API that allows specifying permissions explicitly, and set owner-only read/write permissions (`S_IRUSR | S_IWUSR`, i.e., `0600`) when creating TS files.  
The best fix here is to replace `_xtfopen(..., "wb")` with:

1. `open(..., O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)` to create securely.
2. `fdopen(..., "wb")` to keep existing `FILE*` behavior for downstream code.

This preserves functionality (still writing binary file through `FILE*`) while enforcing restrictive creation mode.  
Edit only the block around line 558 in `XEngine_Source/XEngine_ModuleSession/ModuleSession_PushStream/ModuleSession_PushStream.cpp`.  
Add the required POSIX headers in this file (`<fcntl.h>`, `<sys/stat.h>`, `<unistd.h>`), then replace the fopen assignment/check with open+fdopen and proper error handling (including `close(fd)` if `fdopen` fails).

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。